### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,15 @@ I'd install it first and add its setup line :
 
 - **Managing tabs with bufferline!**
 
+<<<<<<< HEAD
 - <kbd> Shift </kbd> <kbd> l or p </kbd> cycle through opened tabs
 - <kbd> Shift </kbd> <kbd> x </kbd> close current tab
 - <kbd> Shift </kbd> <kbd> t </kbd> open new tab
+=======
+- <kbd> Shift </kbd> <kbd> l or s </kbd> cycle through opened tabs
+- <kbd> Shift </kbd> <kbd> d </kbd> close current tab
+- <kbd> Shift </kbd> <kbd> b </kbd> open new tab
+>>>>>>> parent of 5272eb3 (Update README.md)
 
 # TODO
 

--- a/README.md
+++ b/README.md
@@ -208,15 +208,9 @@ I'd install it first and add its setup line :
 
 - **Managing tabs with bufferline!**
 
-<<<<<<< HEAD
-- <kbd> Shift </kbd> <kbd> l or p </kbd> cycle through opened tabs
-- <kbd> Shift </kbd> <kbd> x </kbd> close current tab
-- <kbd> Shift </kbd> <kbd> t </kbd> open new tab
-=======
 - <kbd> Shift </kbd> <kbd> TAB or Shift TAB </kbd> cycle through opened tabs
 - <kbd> Shift </kbd> <kbd> x </kbd> close current tab
 - <kbd> Shift </kbd> <kbd> t </kbd> open new tab
->>>>>>> parent of 5272eb3 (Update README.md)
 
 # TODO
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ I'd install it first and add its setup line :
 
 - **Managing tabs with bufferline!**
 
-- <kbd> Shift </kbd> <kbd> l or s </kbd> cycle through opened tabs
-- <kbd> Shift </kbd> <kbd> d </kbd> close current tab
-- <kbd> Shift </kbd> <kbd> b </kbd> open new tab
+- <kbd> Shift </kbd> <kbd> , or . </kbd> cycle through opened tabs
+- <kbd> Shift </kbd> <kbd> x </kbd> close current tab
+- <kbd> Shift </kbd> <kbd> t </kbd> open new tab
 
 # TODO
 

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ I'd install it first and add its setup line :
 - <kbd> Shift </kbd> <kbd> x </kbd> close current tab
 - <kbd> Shift </kbd> <kbd> t </kbd> open new tab
 =======
-- <kbd> Shift </kbd> <kbd> l or s </kbd> cycle through opened tabs
-- <kbd> Shift </kbd> <kbd> d </kbd> close current tab
-- <kbd> Shift </kbd> <kbd> b </kbd> open new tab
+- <kbd> Shift </kbd> <kbd> TAB or Shift TAB </kbd> cycle through opened tabs
+- <kbd> Shift </kbd> <kbd> x </kbd> close current tab
+- <kbd> Shift </kbd> <kbd> t </kbd> open new tab
 >>>>>>> parent of 5272eb3 (Update README.md)
 
 # TODO

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ I'd install it first and add its setup line :
 
 - **Managing tabs with bufferline!**
 
-- <kbd> Shift </kbd> <kbd> , or . </kbd> cycle through opened tabs
+- <kbd> Shift </kbd> <kbd> l or p </kbd> cycle through opened tabs
 - <kbd> Shift </kbd> <kbd> x </kbd> close current tab
 - <kbd> Shift </kbd> <kbd> t </kbd> open new tab
 

--- a/lua/top-bufferline.lua
+++ b/lua/top-bufferline.lua
@@ -73,5 +73,5 @@ map("n", "<S-t>", [[<Cmd>tabnew<CR>]], opt)
 map("n", "<S-x>", [[<Cmd>bdelete<CR>]], opt)
 
 -- tabnew and tabprev
-map("n", "<S-,>", [[<Cmd>BufferLineCycleNext<CR>]], opt)
-map("n", "<S-.>", [[<Cmd>BufferLineCyclePrev<CR>]], opt)
+map("n", "<S-l>", [[<Cmd>BufferLineCycleNext<CR>]], opt) -- Another alternate is TAB/S-TAB or C-,/C-.
+map("n", "<S-p>", [[<Cmd>BufferLineCyclePrev<CR>]], opt)

--- a/lua/top-bufferline.lua
+++ b/lua/top-bufferline.lua
@@ -73,5 +73,5 @@ map("n", "<S-t>", [[<Cmd>tabnew<CR>]], opt)
 map("n", "<S-x>", [[<Cmd>bdelete<CR>]], opt)
 
 -- tabnew and tabprev
-map("n", "<S-l>", [[<Cmd>BufferLineCycleNext<CR>]], opt) -- Another alternate is TAB/S-TAB or C-,/C-.
-map("n", "<S-p>", [[<Cmd>BufferLineCyclePrev<CR>]], opt)
+map("n", "<TAB>", [[<Cmd>BufferLineCycleNext<CR>]], opt)
+map("n", "<S-TAB>", [[<Cmd>BufferLineCyclePrev<CR>]], opt)


### PR DESCRIPTION
The Readme keys were not matching the defined keys in top-bufferline.lua.

Also, I tried your keys, but kept the old ones (shift + l | p I think) because shift + , | . doesn't work for me. the shift key changes them from , | . into < | > 

I rebinded on my machine so it works for me.