### PR TITLE
Add `lspinstall` functionality

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -1,4 +1,4 @@
-local function map(mode, lhs, rhs, opts)
+ local function map(mode, lhs, rhs, opts)
     local options = {noremap = true}
     if opts then
         options = vim.tbl_extend("force", options, opts)
@@ -16,13 +16,12 @@ map("v", "dd", [=[ "_dd ]=], opt)
 map("v", "x", [=[ "_x ]=], opt)
 
  this line too ]]
-
 -- OPEN TERMINALS --
-map("n", "<C-l>", [[<Cmd>vnew term://bash<CR>]], opt) -- over right
-map("n", "<C-x>", [[<Cmd> split term://bash| resize 10 <CR>]], opt) --  bottom
-map("n", "<C-t>t", [[<Cmd> tabnew | term <CR>]], opt) -- newtab
+map("n", "<C-l>", [[<Cmd>vnew term://bash <CR>]], opt) -- term over right
+map("n", "<C-x>", [[<Cmd> split term://bash | resize 10 <CR>]], opt) --  term bottom
+map("n", "<C-t>t", [[<Cmd> tabnew | term <CR>]], opt) -- term newtab
 
--- COPY EVERYTHING in the file--
+-- COPY EVERYTHING --
 map("n", "<C-a>", [[ <Cmd> %y+<CR>]], opt)
 
 -- toggle numbers ---
@@ -32,4 +31,5 @@ map("n", "<leader>n", [[ <Cmd> set nu!<CR>]], opt)
 map("n", "<leader>z", [[ <Cmd> TZAtaraxis<CR>]], opt)
 map("n", "<leader>m", [[ <Cmd> TZMinimalist<CR>]], opt)
 
-map("n", "<C-s>", [[ <Cmd> w <CR>]], opt) -- save
+map("n", "<C-s>", [[ <Cmd> w <CR>]], opt)
+-- vim.cmd("inoremap jh <Esc>")

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -18,8 +18,8 @@ map("v", "x", [=[ "_x ]=], opt)
  this line too ]]
 
 -- OPEN TERMINALS --
-map("n", "<C-l>", [[<Cmd>vnew term://zsh <CR>]], opt) -- over right
-map("n", "<C-x>", [[<Cmd> split term://zsh | resize 10 <CR>]], opt) --  bottom
+map("n", "<C-l>", [[<Cmd>vnew term://bash<CR>]], opt) -- over right
+map("n", "<C-x>", [[<Cmd> split term://bash| resize 10 <CR>]], opt) --  bottom
 map("n", "<C-t>t", [[<Cmd> tabnew | term <CR>]], opt) -- newtab
 
 -- COPY EVERYTHING in the file--

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -18,8 +18,8 @@ map("v", "x", [=[ "_x ]=], opt)
  this line too ]]
 
 -- OPEN TERMINALS --
-map("n", "<C-l>", [[<Cmd>vnew term://bash <CR>]], opt) -- over right
-map("n", "<C-x>", [[<Cmd> split term://bash | resize 10 <CR>]], opt) --  bottom
+map("n", "<C-l>", [[<Cmd>vnew term://zsh <CR>]], opt) -- over right
+map("n", "<C-x>", [[<Cmd> split term://zsh | resize 10 <CR>]], opt) --  bottom
 map("n", "<C-t>t", [[<Cmd> tabnew | term <CR>]], opt) -- newtab
 
 -- COPY EVERYTHING in the file--

--- a/lua/nvim-lspconfig.lua
+++ b/lua/nvim-lspconfig.lua
@@ -38,14 +38,14 @@ end
 local lspconf = require("lspconfig")
 
 -- these langs require same lspconfig so put em all in a table and loop through!
-local servers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "ccls"}
+local lspservers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "ccls", "gopls"}
 
-for _, lang in ipairs(servers) do
-    lspconf[lang].setup {
-        on_attach = on_attach,
-        root_dir = vim.loop.cwd
-    }
-end
+for _, lang in ipairs(lspservers) do
+  lspconf[lang].setup {
+     on_attach = on_attach,
+     root_dir = vim.loop.cwd
+ }
+ end
 
 -- vls conf example
 local vls_binary = "/usr/local/bin/vls"
@@ -58,6 +58,29 @@ USER = "/home/" .. vim.fn.expand("$USER")
 
 local sumneko_root_path = USER .. "/.config/lua-language-server"
 local sumneko_binary = USER .. "/.config/lua-language-server/bin/Linux/lua-language-server"
+
+
+local lsp_installer = require'nvim-lsp-installer'
+
+function common_on_attach(client, bufnr)
+    -- setup buffer keymaps etc.
+end
+
+local installed_servers = lsp_installer.get_installed_servers()
+
+for _, server in pairs(installed_servers) do
+    opts = {
+        on_attach = common_on_attach,
+    }
+
+    -- (optional) Customize the options passed to the server
+    -- if server.name == "tsserver" then
+    --     opts.root_dir = function() ... end
+    -- end
+
+    server:setup(opts)
+end
+
 
 lspconf.sumneko_lua.setup {
     cmd = {sumneko_binary, "-E", sumneko_root_path .. "/main.lua"},

--- a/lua/nvim-lspconfig.lua
+++ b/lua/nvim-lspconfig.lua
@@ -62,10 +62,6 @@ local sumneko_binary = USER .. "/.config/lua-language-server/bin/Linux/lua-langu
 
 local lsp_installer = require'nvim-lsp-installer'
 
-function common_on_attach(client, bufnr)
-    -- setup buffer keymaps etc.
-end
-
 local installed_servers = lsp_installer.get_installed_servers()
 
 for _, server in pairs(installed_servers) do

--- a/lua/nvim-lspconfig.lua
+++ b/lua/nvim-lspconfig.lua
@@ -38,9 +38,9 @@ end
 local lspconf = require("lspconfig")
 
 -- these langs require same lspconfig so put em all in a table and loop through!
-local lspservers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "ccls", "gopls"}
+local servers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "ccls", "gopls"}
 
-for _, lang in ipairs(lspservers) do
+for _, lang in ipairs(servers) do
   lspconf[lang].setup {
      on_attach = on_attach,
      root_dir = vim.loop.cwd

--- a/lua/nvim-lspconfig.lua
+++ b/lua/nvim-lspconfig.lua
@@ -110,3 +110,4 @@ vim.fn.sign_define("LspDiagnosticsSignError", {text = "", numhl = "LspDiagnos
 vim.fn.sign_define("LspDiagnosticsSignWarning", {text = "", numhl = "LspDiagnosticsDefaultWarning"})
 vim.fn.sign_define("LspDiagnosticsSignInformation", {text = "", numhl = "LspDiagnosticsDefaultInformation"})
 vim.fn.sign_define("LspDiagnosticsSignHint", {text = "", numhl = "LspDiagnosticsDefaultHint"})
+

--- a/lua/nvim-lspconfig.lua
+++ b/lua/nvim-lspconfig.lua
@@ -42,10 +42,10 @@ local servers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "cc
 
 for _, lang in ipairs(servers) do
   lspconf[lang].setup {
-     on_attach = on_attach,
-     root_dir = vim.loop.cwd
- }
- end
+    on_attach = on_attach,
+    root_dir = vim.loop.cwd
+  }
+end
 
 -- vls conf example
 local vls_binary = "/usr/local/bin/vls"

--- a/lua/nvim-lspconfig.lua
+++ b/lua/nvim-lspconfig.lua
@@ -38,7 +38,7 @@ end
 local lspconf = require("lspconfig")
 
 -- these langs require same lspconfig so put em all in a table and loop through!
-local servers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "ccls", "gopls"}
+local servers = {"html", "cssls", "tsserver", "pyright", "bashls", "clangd", "ccls"}
 
 for _, lang in ipairs(servers) do
   lspconf[lang].setup {

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -4,13 +4,13 @@ local use = packer.use
 -- using { } for using different branch , loading plugin with certain commands etc
 return require("packer").startup(
     function()
+        use 'neovim/nvim-lsp-config'
+        use 'williamboman/nvim-lsp-installer'
         use "wbthomason/packer.nvim"
-
         -- color related stuff
         use "siduck76/nvim-base16.lua"
         use "norcalli/nvim-colorizer.lua"
         -- use "ollykel/v-vim" -- v syntax highlighter
-
         -- lsp stuff
         use "nvim-treesitter/nvim-treesitter"
         use "neovim/nvim-lspconfig"
@@ -46,7 +46,7 @@ return require("packer").startup(
 
         -- discord rich presence
         --use "andweeb/presence.nvim"
-
+        use "wakatime/vim-wakatime"
         use {"lukas-reineke/indent-blankline.nvim", branch = "lua"}
     end,
     {

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -4,18 +4,20 @@ local use = packer.use
 -- using { } for using different branch , loading plugin with certain commands etc
 return require("packer").startup(
     function()
-        use "kabouzeid/nvim-lspinstall"
+        use "wbthomason/packer.nvim"
+
         -- color related stuff
         use "siduck76/nvim-base16.lua"
         use "norcalli/nvim-colorizer.lua"
-        -- use "ollykel/v-vim" -- v syntax highlighter
-        -- lsp stuff
+
+        -- lang stuff
         use "nvim-treesitter/nvim-treesitter"
         use "neovim/nvim-lspconfig"
         use "hrsh7th/nvim-compe"
         use "onsails/lspkind-nvim"
         use "sbdchd/neoformat"
         use "nvim-lua/plenary.nvim"
+        use "kabouzeid/nvim-lspinstall"
 
         use "lewis6991/gitsigns.nvim"
         use "akinsho/nvim-bufferline.lua"
@@ -41,14 +43,11 @@ return require("packer").startup(
         use "karb94/neoscroll.nvim"
         use "kdav5758/TrueZen.nvim"
         use "folke/which-key.nvim"
-
-        -- discord rich presence
-        --use "andweeb/presence.nvim"
         use {"lukas-reineke/indent-blankline.nvim", branch = "lua"}
     end,
     {
         display = {
-            border = { "┌", "─", "┐", "│", "┘", "─", "└", "│" }
+            border = {"┌", "─", "┐", "│", "┘", "─", "└", "│"}
         }
     }
 )

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -4,7 +4,6 @@ local use = packer.use
 -- using { } for using different branch , loading plugin with certain commands etc
 return require("packer").startup(
     function()
-        use 'neovim/nvim-lsp-config'
         use 'williamboman/nvim-lsp-installer'
         use "wbthomason/packer.nvim"
         -- color related stuff
@@ -46,7 +45,6 @@ return require("packer").startup(
 
         -- discord rich presence
         --use "andweeb/presence.nvim"
-        use "wakatime/vim-wakatime"
         use {"lukas-reineke/indent-blankline.nvim", branch = "lua"}
     end,
     {

--- a/lua/pluginList.lua
+++ b/lua/pluginList.lua
@@ -4,8 +4,7 @@ local use = packer.use
 -- using { } for using different branch , loading plugin with certain commands etc
 return require("packer").startup(
     function()
-        use 'williamboman/nvim-lsp-installer'
-        use "wbthomason/packer.nvim"
+        use "kabouzeid/nvim-lspinstall"
         -- color related stuff
         use "siduck76/nvim-base16.lua"
         use "norcalli/nvim-colorizer.lua"


### PR DESCRIPTION
By using [williamboman/nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer) I added an `lspinstall` function to easily allow users to install their own langauge servers. This could probably remove the hardcoded lsps in `nvim-lspcofig.lua` but i didn't want to remove anything yet.